### PR TITLE
Add live recommendation updates on book add

### DIFF
--- a/app.py
+++ b/app.py
@@ -178,12 +178,26 @@ def add_book():
 
     if book_name:
         book_info = get_book_info(book_name)
-        
+
         if book_info:
             liked_books.append(book_info)
-        
-        return jsonify(liked_books)
-    return jsonify([])
+
+    # Prepare recommendations dynamically based on updated list
+    message = ""
+    recommended_books = []
+
+    if len(liked_books) < 3:
+        message = "Add at least 3 books to get recommendations."
+    else:
+        recommended_books = recommend_books(liked_books)
+        if not recommended_books:
+            message = "No recommendations available at the moment."
+
+    return jsonify({
+        'liked_books': liked_books,
+        'recommendations': recommended_books,
+        'message': message
+    })
 
 @app.route('/remove_book', methods=['POST'])
 def remove_book():

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests
 pandas
 numpy
 gensim
+

--- a/static/app.js
+++ b/static/app.js
@@ -13,6 +13,35 @@ function renderLikedBooks(data) {
     });
 }
 
+// Update the recommendation section of the UI
+function updateRecommendationsUI(data) {
+    const recommendedBooksList = document.getElementById('recommended-books-list');
+    recommendedBooksList.innerHTML = '';
+
+    // If a message is provided, show it and hide the list
+    if (data.message) {
+        const messageElement = document.getElementById('recommendation-message');
+        messageElement.textContent = data.message;
+        recommendedBooksList.style.display = 'none';
+        return;
+    }
+
+    const messageElement = document.getElementById('recommendation-message');
+    messageElement.textContent = '';
+    recommendedBooksList.style.display = 'grid';
+
+    (data.recommendations || data).forEach(book => {
+        const bookItem = document.createElement('div');
+        bookItem.className = 'recommended-book-item';
+        bookItem.innerHTML = `
+            <img src="${book.image_url}" alt="${book.title} cover" />
+            <h4>${book.title}</h4>
+            <p>By: ${book.authors}</p>
+        `;
+        recommendedBooksList.appendChild(bookItem);
+    });
+}
+
 function addBookToLiked(bookTitle = null) {
     if (!bookTitle) {
         bookTitle = document.getElementById('liked-book').value;
@@ -34,10 +63,10 @@ function addBookToLiked(bookTitle = null) {
             document.getElementById('autocomplete-results').style.display = 'none';  // Hide dropdown
             
             // Update the liked books list on the UI
-            renderLikedBooks(data);
+            renderLikedBooks(data.liked_books);
 
-            // Now, get and display recommendations
-            getRecommendations();
+            // Update recommendations based on server response
+            updateRecommendationsUI(data);
         })
         .catch(error => {
             console.error('Error:', error);
@@ -98,32 +127,7 @@ function getRecommendations() {
     fetch('/get_recommendations')
         .then(response => response.json())
         .then(data => {
-            const recommendedBooksList = document.getElementById('recommended-books-list');
-            recommendedBooksList.innerHTML = '';  // Clear previous recommendations
-
-            // Handle the case where no recommendations are available
-            if (data.message) {
-                const messageElement = document.getElementById('recommendation-message');
-                messageElement.textContent = data.message;
-                recommendedBooksList.style.display = 'none'; // Hide the recommendations list
-                return;
-            }
-
-            // Show the recommended books
-            const messageElement = document.getElementById('recommendation-message');
-            messageElement.textContent = ''; // Clear any previous messages
-            recommendedBooksList.style.display = 'grid'; // Ensure grid layout for recommendations
-
-            data.forEach(book => {
-                const bookItem = document.createElement('div');
-                bookItem.className = 'recommended-book-item';
-                bookItem.innerHTML = `
-                    <img src="${book.image_url}" alt="${book.title} cover" />
-                    <h4>${book.title}</h4>
-                    <p>By: ${book.authors}</p>
-                `;
-                recommendedBooksList.appendChild(bookItem);
-            });
+            updateRecommendationsUI(data);
         })
         .catch(error => {
             console.error('Error fetching recommendations:', error);


### PR DESCRIPTION
## Summary
- return updated recommendations from `add_book`
- render new recommendations on add without extra API call
- add helper to update the recommendations section
- clean up requirements

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6843bbb0f038832ca55d9cf3d9610fe2