### PR TITLE
Improve recommendation filtering and dropdown behavior

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -80,6 +80,7 @@ function addBookToLiked(bookTitle = null) {
 document.getElementById('liked-book').addEventListener('keydown', function(event) {
     if (event.key === 'Enter') {
         event.preventDefault();  // Prevent form submission or default behavior
+        document.getElementById('autocomplete-results').style.display = 'none';
         addBookToLiked();
     }
 });
@@ -164,10 +165,11 @@ function searchBooks(event) {
                             </div>
                         </div>
                     `;
-                    li.onclick = function() {
-                        addBookToLiked(title);  // Add book when clicked
-                        document.getElementById('autocomplete-results').style.display = 'none';  // Hide dropdown
-                    };
+                    li.addEventListener('mousedown', function(e) {
+                        e.preventDefault();
+                        document.getElementById('autocomplete-results').style.display = 'none';
+                        addBookToLiked(title);
+                    });
                     autocompleteResults.appendChild(li);
                 });
 


### PR DESCRIPTION
## Summary
- augment Google Books calls to fetch more results
- choose best-matching result when adding a book
- hide autocomplete menu when pressing Enter
- add mousedown handler for dropdown selection
- filter recommendations by liked genres and remove duplicates

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6846f3f1dfa8832caa45115d217e7c57